### PR TITLE
Adopt Adwaita application widgets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod storage;
 mod ui;
 mod calendar;
 
-use gtk4::prelude::*;
-use gtk4::Application;
+use libadwaita::prelude::*;
+use libadwaita::Application;
 use ui::HabitApp;
 
 const APP_ID: &str = "com.example.rust-gtk-habits";

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,8 @@
-use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow, Button, Entry, Label, ListBox, ScrolledWindow, Orientation, MessageDialog, Dialog, DialogFlags, ResponseType, CssProvider, Switch, FileChooserDialog, FileChooserAction, FileFilter};
+use libadwaita::prelude::*;
+use libadwaita::{Application, ApplicationWindow, HeaderBar, Toast, ToastOverlay, StyleManager};
+use gtk4::{Button, Entry, Label, ListBox, ScrolledWindow, Orientation, MessageDialog, Dialog, DialogFlags, ResponseType, CssProvider, Switch, FileChooserDialog, FileChooserAction, FileFilter};
 use gtk4::Box as GtkBox;
 use gtk4::glib;
-use libadwaita::prelude::*;
-use libadwaita::{HeaderBar, ActionRow, Toast, ToastOverlay, StyleManager};
 use crate::habit::{Habit, HabitData};
 use crate::storage::SecureStorage;
 use crate::calendar::HabitCalendar;


### PR DESCRIPTION
## Summary
- use `libadwaita::Application` and `ApplicationWindow` for better GNOME look
- clean up unused imports

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68723ffe1208832590a400154085ee41